### PR TITLE
chore: add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+
+/.github export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file to the repo. This ensures that the `.github` folder is not part of the archive.